### PR TITLE
feat: health handler

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -34,8 +34,6 @@ func (h *Handler) write(w http.ResponseWriter, status int, body []byte) {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	log.Print("inside ServeHTTP")
-	log.Print(r)
 	if r.URL != nil && r.URL.Path == "/health" {
 		h.write(w, http.StatusOK, nil)
 		return

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -17,8 +17,8 @@ package handler
 
 import (
 	"bytes"
-    "fmt"
-    "io"
+	"fmt"
+	"io"
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
@@ -34,9 +34,16 @@ func (h *Handler) write(w http.ResponseWriter, status int, body []byte) {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Print("inside ServeHTTP")
+	log.Print(r)
+	if r.URL != nil && r.URL.Path == "/health" {
+		h.write(w, http.StatusOK, nil)
+		return
+	}
+
 	resp, err := h.ProxyClient.Do(r)
 	if err != nil {
-	    errorMsg := "unable to proxy request"
+		errorMsg := "unable to proxy request"
 		log.WithError(err).Error(errorMsg)
 		h.write(w, http.StatusBadGateway, []byte(fmt.Sprintf("%v - %v", errorMsg, err.Error())))
 		return
@@ -46,7 +53,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// read response body
 	buf := bytes.Buffer{}
 	if _, err := io.Copy(&buf, resp.Body); err != nil {
-	    errorMsg := "error while reading response from upstream"
+		errorMsg := "error while reading response from upstream"
 		log.WithError(err).Error(errorMsg)
 		h.write(w, http.StatusInternalServerError, []byte(fmt.Sprintf("%v - %v", errorMsg, err.Error())))
 		return

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -53,8 +52,6 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	}
 
 	healthRequest := BuildHealthRequest()
-	log.Print("healthRequest")
-	log.Print(healthRequest)
 
 	tests := []struct {
 		name    string
@@ -79,6 +76,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			handler: &Handler{
 				ProxyClient: &mockProxyClient{
 					Response: &http.Response{
+						StatusCode: 200,
 						Header: http.Header{
 							"test": []string{"header"},
 						},
@@ -103,7 +101,8 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			request: healthRequest,
 			want: &want{
 				statusCode: http.StatusOK,
-				body:       []byte(`OK`),
+				header:     http.Header{},
+				body:       []byte{},
 			},
 		},
 	}
@@ -112,8 +111,6 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := httptest.NewRecorder()
 
-			log.Print("inside test run")
-			log.Print(tt.request)
 			tt.handler.ServeHTTP(r, tt.request)
 
 			response := r.Result()


### PR DESCRIPTION
Adds a `/health` path (required to deploy as a ALB target)